### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/common/src/main/java/org/mvndaemon/mvnd/common/DaemonConnection.java
+++ b/common/src/main/java/org/mvndaemon/mvnd/common/DaemonConnection.java
@@ -78,7 +78,7 @@ public class DaemonConnection implements AutoCloseable {
             return Message.read(input);
         } catch (EOFException e) {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Discarding EOFException: {}", e.toString(), e);
+                LOGGER.debug("Discarding EOFException: {}", e, e);
             }
             return null;
         } catch (IOException e) {


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:-1424349950 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
